### PR TITLE
cairo:  Configure without egl glesv2

### DIFF
--- a/layers/meta-resin-fsl-arm/recipes-graphics/cairo/cairo_%.bbappend
+++ b/layers/meta-resin-fsl-arm/recipes-graphics/cairo/cairo_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_remove_mx6 = " egl glesv2"


### PR DESCRIPTION
We do not need egl or glsev2, as we only use the framebuffer directly.

Signed-off-by: Theodor Gherzan <theodor@resin.io>

@agherzan @floion 