### PR TITLE
Custom docker images in connectable builds on resin-fsl-arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Custom docker images in connectable builds [Andrei]
 * Bump meta-resin to include connectable builds [Andrei]
 * Add support for optional supervisor image [Andrei]
 * Update meta-resin to v1.2 [Andrei]

--- a/layers/meta-resin-fsl-arm/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
+++ b/layers/meta-resin-fsl-arm/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
@@ -1,5 +1,5 @@
 # Nitrogen6x
-TARGET_REPOSITORY_nitrogen6x = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_nitrogen6x = "resin/armv7hf-supervisor"
 
 # cubox-i
-TARGET_REPOSITORY_cubox-i = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_cubox-i = "resin/armv7hf-supervisor"


### PR DESCRIPTION
Connects to resin-os/meta-resin#133-supervisor-custom-image-tag
@telphan @floion